### PR TITLE
feature: add generic MoonWave style documentation to log

### DIFF
--- a/packages/fleur/init.luau
+++ b/packages/fleur/init.luau
@@ -1,0 +1,1 @@
+return require("src/interface")

--- a/packages/fleur/src/builder/config.luau
+++ b/packages/fleur/src/builder/config.luau
@@ -8,7 +8,12 @@ local Formatter = require("../formatter")
 local Events = require("../../../log-core/src/events/event")
 local indexMeta = require("../../../log-core/src/events/exports")._indexMeta
 
+--[=[
+	@class ConfigBuilder
+
+]=]
 local ConfigBuilder = {}
+
 export type ConfigBuilder = typeof(ConfigBuilder) & {
 	levels: {
 		[string]: number,
@@ -32,6 +37,14 @@ local EVENT_FLEUR_REGISTER = setmetatable(
 	}
 )
 
+--[=[
+	@function new
+	@withn ConfigBuilder
+
+	@param packageName string
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.new(packageName: string)
 	return setmetatable({
 		levels = {},
@@ -41,11 +54,27 @@ function ConfigBuilder.new(packageName: string)
 	})
 end
 
+--[=[
+	@method format
+	@withn ConfigBuilder
+
+	@param format string
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.format(self: ConfigBuilder, format: string)
 	self.formatTmpl = format
 	return self
 end
 
+--[=[
+	@method format
+	@withn ConfigBuilder
+
+	@param level LogScope | number
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.level(self: ConfigBuilder, level: Types.LogScope | number)
 	if typeof(level) == "string" then
 		self.levels["all"] = LOG_SCOPES[level :: Types.LogScope] or error("Unsupported log scope: " .. level)
@@ -58,6 +87,15 @@ function ConfigBuilder.level(self: ConfigBuilder, level: Types.LogScope | number
 	return self
 end
 
+--[=[
+	@method levelFor
+	@withn ConfigBuilder
+
+	@param target string
+	@param level LogScope | number
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.levelFor(self: ConfigBuilder, target: string, level: Types.LogScope | number)
 	if typeof(level) == "string" then
 		self.levels[target] = LOG_SCOPES[level :: Types.LogScope] or error("Unsupported log scope: " .. level)
@@ -70,16 +108,41 @@ function ConfigBuilder.levelFor(self: ConfigBuilder, target: string, level: Type
 	return self
 end
 
+--[=[
+	@method filter
+	@withn ConfigBuilder
+
+	@param predicate (...any) -> boolean
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.filter(self: ConfigBuilder, predicate: (...any) -> boolean)
 	self.filterPredicate = predicate
 	return self
 end
 
+--[=[
+	@method limit
+	@withn ConfigBuilder
+
+	@param limit number
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.limit(self: ConfigBuilder, limit: number)
 	self.truncateLimit = limit
 	return self
 end
 
+--[=[
+	@method logFile
+	@withn ConfigBuilder
+
+	@param filename string
+	@param type "json" | "plaintext"
+
+	@return ConfigBuilder
+]=]
 function ConfigBuilder.logFile(self: ConfigBuilder, filename: string, type: "json" | "plaintext")
 	self.logFilename = Writer:writeAll(filename, {
 		name = self.package,
@@ -89,6 +152,12 @@ function ConfigBuilder.logFile(self: ConfigBuilder, filename: string, type: "jso
 	return self
 end
 
+--[=[
+	@method buildAndApply
+	@withn ConfigBuilder
+
+	@return ()
+]=]
 function ConfigBuilder.buildAndApply(self: ConfigBuilder)
 	local w = Writer
 	w.maxLogLevel = self.levels["all"]

--- a/packages/fleur/src/interface.luau
+++ b/packages/fleur/src/interface.luau
@@ -1,5 +1,6 @@
 local Serde = require("@lune/serde")
 local Fs = require("@lune/fs")
+local Task = require("@lune/task")
 
 local Events = require("../../log-core/src/events/exports")
 local ConfigBuilder = require("builder/config")
@@ -75,15 +76,68 @@ Events.EVENT_LOG_WRITE:listen(function(_: string, logMessage: Types.LogMessage)
 	end
 end)
 
+--[=[
+	@class Fleur
+]=]
 return setmetatable(
 	{
+		--[=[
+			@prop ConfigBuilder ConfigBuilder
+			@withn Fleur
+		]=]
+
 		ConfigBuilder = ConfigBuilder.ConfigBuilder,
 	} :: {
 		ConfigBuilder: ConfigBuilder.ConfigBuilder,
+
+		--[=[
+			@function error
+			@within Fleur
+
+			@param ...any
+
+			@return ()
+		]=]
 		error: (...any) -> (),
+
+		--[=[
+			@function warn
+			@within Fleur
+
+			@param ...any
+
+			@return ()
+		]=]
 		warn: (...any) -> (),
+
+		--[=[
+			@function info
+			@within Fleur
+
+			@param ...any
+
+			@return ()
+		]=]
 		info: (...any) -> (),
+
+		--[=[
+			@function debug
+			@within Fleur
+
+			@param ...any
+
+			@return ()
+		]=]
 		debug: (...any) -> (),
+
+		--[=[
+			@function trace
+			@within Fleur
+
+			@param ...any
+
+			@return ()
+		]=]
 		trace: (...any) -> (),
 	},
 	{
@@ -100,6 +154,8 @@ return setmetatable(
 				return function(...)
 					while impl == nil do
 						print("Waiting for Implementor to be registered")
+
+						Task.wait(0.5)
 					end
 
 					local localImpl: Implementor.Implementor<Writer.FleurWriter> = impl

--- a/packages/log-core/src/buffer.luau
+++ b/packages/log-core/src/buffer.luau
@@ -1,6 +1,11 @@
 local Events = require("events/exports")
 local Types = require("types")
 
+--[=[
+	@class LogBuffer
+	@private
+
+]=]
 local LogBuffer = {}
 
 export type LogBuffer = typeof(LogBuffer) & {
@@ -9,6 +14,15 @@ export type LogBuffer = typeof(LogBuffer) & {
 	store: { Types.LogMessage },
 }
 
+--[=[
+	@method append
+	@within Implementor
+
+	@param writer Writer
+	@param options { truncate: boolean, scope: LogScope, target: string }?
+
+	@return ()
+]=]
 function LogBuffer.append<W>(
 	self: LogBuffer,
 	writer: Types.Writer<W>,

--- a/packages/log-core/src/events/event.luau
+++ b/packages/log-core/src/events/event.luau
@@ -1,5 +1,11 @@
 local Uuid = require("../../vendor/uuid")
 
+--[=[
+	@class Event
+	@private
+
+
+]=]
 local Event = {}
 
 export type Listener<T...> = {
@@ -14,6 +20,14 @@ export type Event<T...> = typeof(Event) & {
 	_disposed: boolean,
 }
 
+--[=[
+	@method listen
+	@within Event
+
+	@param handler (registrarId: string, unknown...) -> ()
+
+	@return string
+]=]
 function Event.listen<T...>(self: Event<T...>, handler: (registrarId: string, T...) -> ())
 	local registrarId = Uuid()
 
@@ -29,6 +43,15 @@ function Event.listen<T...>(self: Event<T...>, handler: (registrarId: string, T.
 	return registrarId
 end
 
+--[=[
+	@method _fire
+	@within Event
+
+	@param registrarId string
+	@param ... ...any
+
+	@return ()
+]=]
 function Event._fire<T...>(self: Event<T...>, registrarId: string?, ...)
 	for _, listener in self.listeners do
 		if registrarId and listener.registrar == registrarId then

--- a/packages/log-core/src/events/exports.luau
+++ b/packages/log-core/src/events/exports.luau
@@ -11,8 +11,20 @@ local function indexMeta<I, T...>(self: Event<T...>, idx: I)
 	return nil
 end
 
+--[=[
+	@class Exports
+	@private
+
+
+]=]
 return {
 	_indexMeta = indexMeta,
+
+	--[=[
+		@prop EVENT_READY Event
+		@within Exports
+	]=]
+
 	EVENT_READY = setmetatable(
 		{
 			id = "ready",
@@ -23,6 +35,11 @@ return {
 			__index = indexMeta,
 		}
 	),
+
+	--[=[
+		@prop EVENT_REGISTERED Event
+		@within Exports
+	]=]
 
 	EVENT_REGISTERED = setmetatable(
 		{
@@ -35,6 +52,11 @@ return {
 		}
 	),
 
+	--[=[
+		@prop EVENT_UNREGISTERED Event
+		@within Exports
+	]=]
+
 	EVENT_UNREGISTERED = setmetatable(
 		{
 			id = "unregistered",
@@ -46,6 +68,11 @@ return {
 		}
 	),
 
+	--[=[
+		@prop EVENT_LOG_APPEND Event
+		@within Exports
+	]=]
+
 	EVENT_LOG_APPEND = setmetatable(
 		{
 			id = "logAppend",
@@ -56,6 +83,11 @@ return {
 			__index = indexMeta,
 		}
 	),
+
+	--[=[
+		@prop EVENT_LOG_WRITE Event
+		@within Exports
+	]=]
 
 	EVENT_LOG_WRITE = setmetatable(
 		{

--- a/packages/log-core/src/implementor.luau
+++ b/packages/log-core/src/implementor.luau
@@ -2,8 +2,15 @@ local Types = require("types")
 local Events = require("events/exports")
 local LogBuffer = require("buffer")
 
+--[=[
+	@class Implementor
+
+
+]=]
 local Implementor = {}
+
 Implementor.Prototype = {}
+
 export type Implementor<W> = typeof(Implementor.Prototype) & {
 	writer: Types.Writer<W>?,
 	formatter: Types.Formatter,
@@ -18,6 +25,16 @@ local _unregisterEventId = Events.EVENT_UNREGISTERED:listen(function(_: string)
 	isRegistered = false
 end)
 
+--[=[
+	@function register
+	@within Implementor
+
+	@param writer Writer
+	@param formatter Formatter
+	@param options { truncateLimite: number?, existingStore: { LogMessage? }? }?
+
+	@return Implementor
+]=]
 function Implementor.register<T>(
 	writer: Types.Writer<T>,
 	formatter: Types.Formatter,
@@ -50,14 +67,37 @@ function Implementor.register<T>(
 	return impl
 end
 
+--[=[
+	@method unregister
+	@within Implementor
+
+	@return ()
+]=]
 function Implementor.unregister<W>(self: Implementor<W>)
 	Events.EVENT_UNREGISTERED:_fire(nil, self)
 end
 
+--[=[
+	@method getImplementorInstance
+	@within Implementor
+
+	@return Implementor
+]=]
 function Implementor.Prototype.getImplementorInstance<W>(self: Implementor<W>)
 	return self
 end
 
+--[=[
+	@method log
+	@within Implementor
+
+	@param target string
+	@param scope LogScope
+	@param writer Writer
+	@param toTruncate boolean
+
+	@return Implementor
+]=]
 function Implementor.Prototype.log<W>(
 	self: Implementor<W>,
 	target: string,

--- a/packages/log-core/src/init.luau
+++ b/packages/log-core/src/init.luau
@@ -1,6 +1,20 @@
 local Log = require("methods")
 local Implementor = require("implementor")
 
+--[=[
+	@class LogCore
+]=]
+
+--[=[
+	@prop Log Log
+	@within LogCore
+]=]
+
+--[=[
+	@prop Implementor Implementor
+	@within LogCore
+]=]
+
 return {
 	Log = Log,
 	Implementor = Implementor,

--- a/packages/log-core/src/methods.luau
+++ b/packages/log-core/src/methods.luau
@@ -3,12 +3,72 @@ local Types = require("types")
 
 type LogMethod = <W>(impl: Implementor.Implementor<W>, target: string, writer: Types.Writer<W>?) -> ()
 
+--[=[
+	@class Log
+
+	Internal Log class that developers use to create logs
+]=]
+
 return setmetatable(
 	{} :: {
+		--[=[
+			@function error
+			@within Log
+
+			@param impl Implementor
+			@param target string
+			@param writer Writer
+
+			@return ()
+		]=]
 		error: LogMethod,
+
+		--[=[
+			@function warn
+			@within Log
+
+			@param impl Implementor
+			@param target string
+			@param writer Writer
+
+			@return ()
+		]=]
 		warn: LogMethod,
+
+		--[=[
+			@function info
+			@within Log
+
+			@param impl Implementor
+			@param target string
+			@param writer Writer
+
+			@return ()
+		]=]
 		info: LogMethod,
+
+		--[=[
+			@function debug
+			@within Log
+
+			@param impl Implementor
+			@param target string
+			@param writer Writer
+
+			@return ()
+		]=]
 		debug: LogMethod,
+
+		--[=[
+			@function trace
+			@within Log
+
+			@param impl Implementor
+			@param target string
+			@param writer Writer
+
+			@return ()
+		]=]
 		trace: LogMethod,
 	},
 	{

--- a/packages/log-core/src/types.luau
+++ b/packages/log-core/src/types.luau
@@ -5,14 +5,23 @@ export type LogMessage = {
 	target: string,
 }
 
+--[=[
+	@type LogScope "INFO" | "WARN" | "ERROR" | "DEBUG" | "TRACE"
+]=]
 export type LogScope = "INFO" | "WARN" | "ERROR" | "DEBUG" | "TRACE"
 
+--[=[
+	@type Writer { enabled: (self: Writer, scope: LogScope) -> boolean, writeAll: (self: Writer, ...any) -> string, flush: boolean }
+]=]
 export type Writer<T> = {
 	enabled: (self: Writer<T>, scope: LogScope) -> boolean,
 	writeAll: (self: Writer<T>, ...any) -> string,
 	flush: boolean,
 } & T
 
+--[=[
+	@type Formatter { fmt: (self: Formatter, message: LogMessage) -> string }
+]=]
 export type Formatter = {
 	fmt: (self: Formatter, message: LogMessage) -> string,
 }


### PR DESCRIPTION
Adding generic Moonwave documentation to the various classes end developers may be exposed too. 

---

I am yet to fill out the details on this module, at the moment it's just the links between each module so that a Moonwave site can be generated :smile: 